### PR TITLE
checking if forker's dependencies were installed before start

### DIFF
--- a/bin/forker.php
+++ b/bin/forker.php
@@ -1,6 +1,13 @@
 #!/usr/bin/env php
 <?php
-require_once 'vendor/autoload.php';
+$forkerDirectory = dirname(__DIR__);
+
+if (!is_file($forkerDirectory . '/composer.lock')) {
+    echo 'You must run composer install before use forker' . PHP_EOL;
+    exit;
+}
+
+require_once $forkerDirectory . '/vendor/autoload.php';
 
 use kinncj\Forker\Command\Fork;
 use Symfony\Component\Console\Application;

--- a/forker
+++ b/forker
@@ -11,4 +11,4 @@ for (( i=0;i<$ELEMENTS;i++)); do
     SCRIPT+=" ${args[${i}]}"
 done
 
-php bin/forker.php $SCRIPT
+php "$( dirname "${BASH_SOURCE[0]}" )/bin/forker.php" $SCRIPT


### PR DESCRIPTION
Just a little check for composer.lock before start forker.
